### PR TITLE
INFRA-149: Pinning Az PS modules to version 10.4.1

### DIFF
--- a/.github/actions/initialize/action.yml
+++ b/.github/actions/initialize/action.yml
@@ -23,8 +23,8 @@ runs:
     - name: Install and Import Modules
       shell: pwsh
       run: |
-        Install-Module Az -AllowClobber -Force
-        Install-Module SqlServer -AllowClobber -Force
+        Install-Module Az -RequiredVersion 10.4.1 -AllowClobber -Force
+        Install-Module SqlServer -RequiredVersion 22.1.1 -AllowClobber -Force
 
         foreach ($moduleName in (Get-ChildItem -Directory | select Name))
         {

--- a/.github/actions/initialize/action.yml
+++ b/.github/actions/initialize/action.yml
@@ -23,10 +23,8 @@ runs:
     - name: Install and Import Modules
       shell: pwsh
       run: |
-        Install-Module Az.Storage -RequiredVersion 5.10.1 -AllowClobber -Force
-        Install-Module Az.Sql -RequiredVersion 4.10.0 -AllowClobber -Force
-        Install-Module Az.Websites -RequiredVersion 3.1.1 -AllowClobber -Force
-        Install-Module SqlServer -AllowClobber -Force
+        Install-Module Az -RequiredVersion 10.4.1 -AllowClobber -Force
+        Install-Module SqlServer -RequiredVersion 22.1.1 -AllowClobber -Force
 
         foreach ($moduleName in (Get-ChildItem -Directory | select Name))
         {

--- a/.github/actions/initialize/action.yml
+++ b/.github/actions/initialize/action.yml
@@ -23,9 +23,9 @@ runs:
     - name: Install and Import Modules
       shell: pwsh
       run: |
-        Install-Module Az.Storage -AllowClobber -Force
-        Install-Module Az.Sql -AllowClobber -Force
-        Install-Module Az.Websites -AllowClobber -Force
+        Install-Module Az.Storage -RequiredVersion 5.10.1 -AllowClobber -Force
+        Install-Module Az.Sql -RequiredVersion 4.10.0 -AllowClobber -Force
+        Install-Module Az.Websites -RequiredVersion 3.1.1 -AllowClobber -Force
         Install-Module SqlServer -AllowClobber -Force
 
         foreach ($moduleName in (Get-ChildItem -Directory | select Name))

--- a/.github/actions/initialize/action.yml
+++ b/.github/actions/initialize/action.yml
@@ -23,8 +23,8 @@ runs:
     - name: Install and Import Modules
       shell: pwsh
       run: |
-        Install-Module Az -RequiredVersion 10.4.1 -AllowClobber -Force
-        Install-Module SqlServer -RequiredVersion 22.1.1 -AllowClobber -Force
+        Install-Module Az -AllowClobber -Force
+        Install-Module SqlServer -AllowClobber -Force
 
         foreach ($moduleName in (Get-ChildItem -Directory | select Name))
         {

--- a/.github/actions/initialize/action.yml
+++ b/.github/actions/initialize/action.yml
@@ -33,3 +33,5 @@ runs:
             Import-Module $moduleName.Name
           }
         }
+
+        Get-Module -ListAvailable


### PR DESCRIPTION
[INFRA-149](https://lombiq.atlassian.net/browse/INFRA-149)
Previously we installed the latest version of Az.Storage, Az.Sql and Az.Websites. With the recent release of Az modules, Az.Storage version 6.0.0 is installed, but when running `Invoke-AzureWebAppStorageAzCopy` in GitHub Actions (during [reset-azure-environment](https://github.com/Lombiq/GitHub-Actions/blob/dev/.github/workflows/reset-azure-environment.yml)), it fails with this error:

> Cannot perform sync due to error: Login Credentials missing. No SAS token or OAuth token is present and the resource is not public

Works fine locally. The DB copy operation in the workflow also failed, so we're installing the whole Az PS module package at the last known working version (that includes Az.Storage 5.10.1).

[INFRA-149]: https://lombiq.atlassian.net/browse/INFRA-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ